### PR TITLE
Sockstat metrics

### DIFF
--- a/bin/metrics-sockstat.rb
+++ b/bin/metrics-sockstat.rb
@@ -1,13 +1,39 @@
 #!/usr/bin/env ruby
-
+#
+# metrics-sockstat
+#
+# DESCRIPTION:
+#   This metric check parses /proc/net/sockstat and outputs all fields as metrics
+#
+# OUTPUT:
+#   graphite
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   None
+#
+# USAGE:
+#   Specify [-s|--scheme] SCHEME to change the text appended to the metric paths.
+#
+# NOTES:
+#   It outputs the value in the first line ("sockets used") as SCHEME.total_used.
+#   All other fields are output as SCHEME.type.field, i.e., SCHEME.TCP.inuse, SCHEME.UDP.mem 
+#
+# LICENSE:
+#   Copyright 2015 Contegix, LLC.
+#   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
+#
 require 'sensu-plugin/metric/cli'
 
+# Sockstat
 class Sockstat < Sensu::Plugin::Metric::CLI::Graphite
   option :scheme,
-    description: 'Metric naming scheme, text to prepend to $protocol.$field',
-    long: '--scheme SCHEME',
-    short: '-s SCHEME',
-    default: 'network.sockets'
+         description: 'Metric naming scheme, text to prepend to $protocol.$field',
+         long: '--scheme SCHEME',
+         short: '-s SCHEME',
+         default: 'network.sockets'
 
   def output_metric(name, value)
     output "#{@config[:scheme]}.#{name} #{value} #{@timestamp}"
@@ -27,11 +53,9 @@ class Sockstat < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def read_sockstat
-    begin
-      return IO.read('/proc/net/sockstat')
+    return IO.read('/proc/net/sockstat')
     rescue => e
-      unknown "Failed to read /proc/net/sockstat: #{e}"
-    end
+    unknown "Failed to read /proc/net/sockstat: #{e}"
   end
 
   def run

--- a/bin/metrics-sockstat.rb
+++ b/bin/metrics-sockstat.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+
+require 'sensu-plugin/metric/cli'
+
+class Sockstat < Sensu::Plugin::Metric::CLI::Graphite
+  option :scheme,
+    description: 'Metric naming scheme, text to prepend to $protocol.$field',
+    long: '--scheme SCHEME',
+    short: '-s SCHEME',
+    default: 'network.sockets'
+
+  def output_metric(name, value)
+    output "#{@config[:scheme]}.#{name} #{value} #{@timestamp}"
+  end
+
+  def socket_metrics(fields)
+    name = 'total_used'
+    value = fields[2]
+    output_metric(name, value)
+  end
+
+  def generic_metrics(fields)
+    proto = fields[0].sub(':', '')
+    fields[1..-1].join(' ').scan(/([A-Za-z]+) (\d+)/).each do |tuple|
+      output_metric("#{proto}.#{tuple[0]}", tuple[1])
+    end
+  end
+
+  def read_sockstat
+    begin
+      return IO.read('/proc/net/sockstat')
+    rescue => e
+      unknown "Failed to read /proc/net/sockstat: #{e}"
+    end
+  end
+
+  def run
+    sockstat = read_sockstat
+    @config = config
+    @timestamp = Time.now.to_i
+    sockstat.split("\n").each do |line|
+      fields = line.split
+      if fields[0] == 'sockets:'
+        socket_metrics(fields)
+      elsif fields.length > 1
+        generic_metrics(fields)
+      end
+    end
+    ok
+  end
+end

--- a/sensu-plugins-network-checks.gemspec
+++ b/sensu-plugins-network-checks.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.require_paths          = ["lib"]
   s.cert_chain             = ["certs/sensu-plugins.pem"]
   s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
-  s.platform               = ruby
+  s.platform               = 'ruby'
   s.required_ruby_version  = '>= 1.9.3'
 
 

--- a/test/metrics-sockstat_spec.rb
+++ b/test/metrics-sockstat_spec.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+#
+# metrics-sockstat_spec
+#
+# DESCRIPTION:
+#   Tests for metrics-sockstat.rb
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#
+# DEPENDENCIES:
+#
+# USAGE:
+#   bundle install
+#   rake spec
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2015 Contegix, LLC.
+#   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
+#
+require_relative './plugin_stub.rb'
+require_relative './spec_helper.rb'
+require_relative '../bin/metrics-sockstat.rb'
+
+RSpec.configure do |c|
+  c.before { allow($stdout).to receive(:puts) }
+  c.before { allow($stderr).to receive(:puts) }
+end
+
+describe Sockstat, 'run' do
+
+  it 'should successfully output socket metrics for the total number of sockets and any other types that are present' do
+    sockstat = Sockstat.new
+    allow(sockstat).to receive(:read_sockstat).and_return("sockets: used 10\nFOO: bar 5 baz 4")
+    allow(sockstat).to receive(:output)
+    expect(sockstat).to receive(:output).with(match('total_used 10'))
+    expect(sockstat).to receive(:output).with(match('FOO.bar 5'))
+    expect(sockstat).to receive(:output).with(match('FOO.baz 4'))
+    expect(-> { sockstat.run }).to raise_error SystemExit
+  end
+
+end

--- a/test/plugin_stub.rb
+++ b/test/plugin_stub.rb
@@ -1,0 +1,23 @@
+RSpec.configure do |c|
+  # XXX: Sensu plugins run in the context of an at_exit handler. This prevents
+  # XXX: code-under-test from being run at the end of the rspec suite.
+  c.before(:each) do
+    Sensu::Plugin::CLI.class_eval do
+      # PluginStub
+      class PluginStub
+        def run; end
+
+        def ok(*); end
+
+        def warning(*); end
+
+        def critical(*); end
+
+        def unknown(*); end
+      end
+      # rubocop:disable all
+      class_variable_set(:@@autorun, PluginStub)
+      # rubocop:enable all
+    end
+  end
+end


### PR DESCRIPTION
This adds a metric check that parses /proc/net/sockstat on Linux systems and outputs all fields as metrics. Tests are included.