### PR TITLE
check-ports: support port ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased][unreleased]
-- nothing
+- Support multiple port ranges for check-ports
 
 ## [0.0.7] - 2015-10-27
 ### Added


### PR DESCRIPTION
Support multiple port ranges

```
$ ./check-ports.rb -H localhost -p 8103,8110-8120,8104 -t 30
CheckPort OK: All ports (8103,8110-8120,8104) are accessible for host localhost
```