### PR TITLE
Added include and ignore options for devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Added
+- Added include and ignore options for devices at `metrics-net.rb`
 
 ## [0.0.8] - 2015-11-12
 ### Added


### PR DESCRIPTION
Devices now can be specifically included or ignored using `-i` or `-I` options