### PR TITLE
lock activesupport gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+## [0.1.1] - 2015-12-21
+### Added
+- activesupport runtime dependency locked to 4.2.5 to ensure that we do not need ruby > 2.2
+
 ## [0.1.0] - 2015-12-03
 ### Added
 - Added include and ignore options for devices at `metrics-net.rb`

--- a/lib/sensu-plugins-network-checks/version.rb
+++ b/lib/sensu-plugins-network-checks/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsNetworkChecks
   module Version
     MAJOR = 0
     MINOR = 1
-    PATCH = 0
+    PATCH = 1
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-network-checks.gemspec
+++ b/sensu-plugins-network-checks.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sensu-plugin',  '1.2.0'
   s.add_runtime_dependency 'net-ping',      '1.7.8'
   s.add_runtime_dependency 'whois',         '3.6.3'
+  s.add_runtime_dependency 'activesupport', '4.2.5'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
adding runtime dep for activesupport 4.2.5 to ensure that you do not need ruby >= 2.2

```
STDERR: ERROR:  Error installing sensu-plugins-network-checks:
    activesupport requires Ruby version >= 2.2.2.
---- End output of /opt/rbenv/shims/gem install sensu-plugins-network-checks -q --no-rdoc --no-ri -v "0.0.2" ----
Ran /opt/rbenv/shims/gem install sensu-plugins-network-checks -q --no-rdoc --no-ri -v "0.0.2" returned 1

Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/cc-sensu/recipes/community_plugins.rb

 89: gem_package 'sensu-plugins-network-checks' do
 90:   version '0.0.2'
 91: end
 92: 

Compiled Resource:
------------------
# Declared in /var/chef/cache/cookbooks/cc-sensu/recipes/community_plugins.rb:89:in `from_file'

gem_package("sensu-plugins-network-checks") do
  action [:install]
  retries 0
  retry_delay 2
  default_guard_interpreter :default
  package_name "sensu-plugins-network-checks"
  version "0.0.2"
  declared_type :gem_package
  cookbook_name "cc-sensu"
  recipe_name "community_plugins"
  gem_binary "/opt/rbenv/shims/gem"
end
```
https://rubygems.org/gems/activesupport/versions/5.0.0.beta1

4.2.5 is the last stable version and does not require ruby >= 2.2


