### PR TITLE
bugfix: return warning if there are items in the warning hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+### Changed
+- Bugfix for `check-whois-domain-expiration-multi` and `check-jsonwhois-domain-expiration`: return a warning-level response if there were any domains with expiration dates in the warning time period but none in the critical time period.
+
 ## [0.1.1] - 2015-12-21
 ### Added
 - activesupport runtime dependency locked to 4.2.5 to ensure that we do not need ruby > 2.2

--- a/bin/check-jsonwhois-domain-expiration.rb
+++ b/bin/check-jsonwhois-domain-expiration.rb
@@ -117,6 +117,7 @@ class JSONWhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
     if !status['critical'].empty?
       critical status['critical'].map { |u, v| "#{u} days left:#{v}" }.join(',')
     elsif !status['warning'].empty?
+      warning status['warning'].map { |u, v| "#{u} days left:#{v}" }.join(',')
     else
       ok 'No domains expire in the near term'
     end

--- a/bin/check-whois-domain-expiration-multi.rb
+++ b/bin/check-whois-domain-expiration-multi.rb
@@ -91,6 +91,7 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
     if !status['critical'].empty?
       critical status['critical'].map { |u, v| "#{u} days left:#{v}" }.join(',')
     elsif !status['warning'].empty?
+      warning status['warning'].map { |u, v| "#{u} days left:#{v}" }.join(',')
     else
       ok 'No domains expire in the near term'
     end


### PR DESCRIPTION
Fixes a bug in `check-whois-domain-expiration-multi` where the check would fail to exit if there were any domains with expiration dates in the `warning` time period but none in the `critical` time period.

The bug was copied to `check-jsonwhois-domain-expiration` at creation.