### PR TITLE
Add ipv6 support for check-ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Added
+- IPv6 support for check-ping
 
 ## [0.1.2] - 2016-01-08
 ### Fixed

--- a/bin/check-ping.rb
+++ b/bin/check-ping.rb
@@ -37,6 +37,12 @@ class CheckPING < Sensu::Plugin::Check::CLI
          short: '-h host',
          default: 'localhost'
 
+  option :ipv6,
+         short: '-6',
+         long: '--ipv6',
+         description: 'Ping IPv6 address',
+         default: false
+
   option :timeout,
          short: '-T timeout',
          proc: proc(&:to_i),
@@ -75,9 +81,10 @@ class CheckPING < Sensu::Plugin::Check::CLI
   def run
     result = []
     pt = Net::Ping::External.new(config[:host], nil, config[:timeout])
+    config[:ipv6] ? (ping = pt.ping6) : (ping = pt.ping)
     config[:count].times do |i|
       sleep(config[:interval]) unless i == 0
-      result[i] = pt.ping?
+      result[i] = ping
     end
 
     successful_count = result.count(true)

--- a/sensu-plugins-network-checks.gemspec
+++ b/sensu-plugins-network-checks.gemspec
@@ -50,8 +50,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'github-markup',             '~> 1.3'
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.0'
+  s.add_development_dependency 'rdoc',                      '~> 4.2.1'
+  s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '0.32.1'
-  s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
I added ipv6 support for check-ping. Unfortunately there were no unit tests for check-ping at all to add ipv6 test cases :-(