### PR TITLE
fixed metrics-ping statistic order

### DIFF
--- a/bin/metrics-ping.rb
+++ b/bin/metrics-ping.rb
@@ -64,7 +64,7 @@ class PingMetrics < Sensu::Plugin::Check::CLI
          default: 5
 
   OVERVIEW_METRICS = [:packets_transmitted, :packets_received, :packet_loss, :time]
-  STATISTIC_METRICS = [:min, :max, :avg, :mdev]
+  STATISTIC_METRICS = [:min, :avg, :max, :mdev]
   FLOAT = '(\d+\.\d+)'
 
   def overview


### PR DESCRIPTION
`ping` result:

```
rrt min/avg/max/mdev = 14.465/21.527/28.589/7.062 ms
```

The order is `min`,`avg`,`max`,`mdev`