### PR TITLE
metrics-ping.rb: added a warning about different 'ping' versions

### DIFF
--- a/bin/metrics-ping.rb
+++ b/bin/metrics-ping.rb
@@ -22,6 +22,12 @@
 #   gem: sensu-plugin
 #   gem: open3
 #
+# WARNING:
+#  This plugins requires `ping` binary from `iputils-ping` package.
+#  `ping` binary from `inetutils-ping` package produces incompatible
+#  output. For more info see:
+#  https://github.com/sensu-plugins/sensu-plugins-network-checks/issues/26
+#
 # USAGE:
 #   ./metric-ping --host <host> --count <count> \
 #                 --timeout <timeout> --scheme <scheme>


### PR DESCRIPTION
This PR adds warning as requested in #26 
Btw: I'm not a Ruby developer so I haven't tested if this script is still working. It should since I only added a comment.