### PR TITLE
Handle whois errors better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Fixed
 - metrics-ping.rb: Fix error when a host can't be pinged. Convert to a proper metrics check.
+- check-whois-domain-expiration-multi.rb: Handle whois errors better by retrying failed lookups
 
 ### Added
 - Option for newline character in write string for check-banner
+- check-whois-domain-expiration-multi.rb: Add timeout option
 
 ## [0.1.4] - 2016-01-22
 ### Added


### PR DESCRIPTION
Add `timeout` option and increase to 10 seconds - whois gem defaults to 5 seconds, which is too short for some whois servers. Also retry connection errors.

Before: 

```
/opt/sensu/embedded/bin/check-whois-domain-expiration-multi.rb -d ... -w 30 -c 7
Check failed to run: Errno::ECONNRESET: Connection reset by peer, ["/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois/server/socket_handler.rb:40:in `rescue in call'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois/server/socket_handler.rb:38:in `call'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois/server/adapters/base.rb:175:in `query'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois/server/adapters/verisign.rb:33:in `request'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois/server/adapters/base.rb:107:in `block in lookup'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois/server/adapters/base.rb:143:in `buffer_start'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois/server/adapters/base.rb:106:in `lookup'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois/client.rb:94:in `block in lookup'", "/opt/sensu/embedded/lib/ruby/2.2.0/timeout.rb:88:in `block in timeout'", "/opt/sensu/embedded/lib/ruby/2.2.0/timeout.rb:32:in `block in catch'", "/opt/sensu/embedded/lib/ruby/2.2.0/timeout.rb:32:in `catch'", "/opt/sensu/embedded/lib/ruby/2.2.0/timeout.rb:32:in `catch'", "/opt/sensu/embedded/lib/ruby/2.2.0/timeout.rb:103:in `timeout'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois/client.rb:91:in `lookup'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/whois-3.6.3/lib/whois.rb:42:in `lookup'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/sensu-plugins-network-checks-0.1.4/bin/check-whois-domain-expiration-multi.rb:76:in `block in expiration_results'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/sensu-plugins-network-checks-0.1.4/bin/check-whois-domain-expiration-multi.rb:75:in `each'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/sensu-plugins-network-checks-0.1.4/bin/check-whois-domain-expiration-multi.rb:75:in `expiration_results'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/sensu-plugins-network-checks-0.1.4/bin/check-whois-domain-expiration-multi.rb:90:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```

After: 

```
/opt/sensu/embedded/bin/check-whois-domain-expiration-multi.rb -d ... -w 30 -c 7
WhoisDomainExpirationCheck OK: No domains expire in the near term
```

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues
