### PR TITLE
Use Timeout.timeout not deprecated Object#timeout.

### DIFF
--- a/bin/check-banner.rb
+++ b/bin/check-banner.rb
@@ -102,7 +102,7 @@ class CheckBanner < Sensu::Plugin::Check::CLI
          description: 'Custom critical message to send'
 
   def acquire_banner(host)
-    timeout(config[:timeout]) do
+    Timeout.timeout(config[:timeout]) do
       sock = TCPSocket.new(host, config[:port])
       if config[:write]
         sock.write config[:write]
@@ -125,7 +125,7 @@ class CheckBanner < Sensu::Plugin::Check::CLI
   end
 
   def acquire_no_banner(host)
-    timeout(config[:timeout]) do
+    Timeout.timeout(config[:timeout]) do
       TCPSocket.new(host, config[:port])
     end
   rescue Errno::ECONNREFUSED

--- a/bin/check-ports.rb
+++ b/bin/check-ports.rb
@@ -62,7 +62,7 @@ class CheckPort < Sensu::Plugin::Check::CLI
          default: 30
 
   def check_port(port)
-    timeout(config[:timeout]) do
+    Timeout.timeout(config[:timeout]) do
       config[:proto].casecmp('tcp').zero? ? TCPSocket.new(config[:host], port.to_i) : UDPSocket.open.connect(config[:host], port.to_i)
     end
   rescue Errno::ECONNREFUSED


### PR DESCRIPTION
From ruby 2.3.0, use of Object#timeout prints a deprecation warning:

    Object#timeout is deprecated, use Timeout.timeout instead