### PR TITLE
Metrics netstat tcp disable tcp6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Fixed
+- metrics-netstat-tcp.rb: Option to disable IPv6 check (#44 via @MattMencel)
+- 
 ## [1.1.0] - 2016-08-07
 ### Added
 - metrics-netstat-tcp.rb: Add IPv6 state counts (@mlf4aiur)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Fixed
 - metrics-netstat-tcp.rb: Option to disable IPv6 check (#44 via @MattMencel)
-- 
+
 ## [1.1.0] - 2016-08-07
 ### Added
 - metrics-netstat-tcp.rb: Add IPv6 state counts (@mlf4aiur)

--- a/bin/metrics-netstat-tcp.rb
+++ b/bin/metrics-netstat-tcp.rb
@@ -76,6 +76,12 @@ class NetstatTCPMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--port PORT',
          proc: proc(&:to_i)
 
+  option :disabletcp6,
+         description: 'Disable tcp6 check',
+         short: '-d',
+         long: '--disabletcp6',
+         boolean: true
+         
   def netstat(protocol, pattern, state_counts)
     File.open('/proc/net/' + protocol).each do |line|
       line.strip!
@@ -101,8 +107,10 @@ class NetstatTCPMetrics < Sensu::Plugin::Metric::CLI::Graphite
     tcp4_pattern = /^\s*\d+:\s+(.{8}):(.{4})\s+(.{8}):(.{4})\s+(.{2})/
     state_counts = netstat('tcp', tcp4_pattern, state_counts)
 
-    tcp6_pattern = /^\s*\d+:\s+(.{32}):(.{4})\s+(.{32}):(.{4})\s+(.{2})/
-    state_counts = netstat('tcp6', tcp6_pattern, state_counts)
+    unless config[:disabletcp6]
+      tcp6_pattern = /^\s*\d+:\s+(.{32}):(.{4})\s+(.{32}):(.{4})\s+(.{2})/
+      state_counts = netstat('tcp6', tcp6_pattern, state_counts)
+    end
 
     state_counts.each do |state, count|
       graphite_name = config[:port] ? "#{config[:scheme]}.#{config[:port]}.#{state}" :

--- a/bin/metrics-netstat-tcp.rb
+++ b/bin/metrics-netstat-tcp.rb
@@ -81,7 +81,7 @@ class NetstatTCPMetrics < Sensu::Plugin::Metric::CLI::Graphite
          short: '-d',
          long: '--disabletcp6',
          boolean: true
-         
+
   def netstat(protocol, pattern, state_counts)
     File.open('/proc/net/' + protocol).each do |line|
       line.strip!


### PR DESCRIPTION
Adding an option to disable the tcp6 check.  On nodes where tcp6 is disabled, this metric check throws errors because...

Check failed to run: No such file or directory @ rb_sysopen - /proc/net/tcp6