### PR TITLE
check-banner.rb: Option to enable SSL socket for secure connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Fixed
 - metrics-netstat-tcp.rb: Option to disable IPv6 check (#44 via @MattMencel)
 
+### Changed
+- check-banner.rb: Option to enable SSL socket for secure connection
+
 ## [1.1.0] - 2016-08-07
 ### Added
 - metrics-netstat-tcp.rb: Add IPv6 state counts (@mlf4aiur)

--- a/bin/check-banner.rb
+++ b/bin/check-banner.rb
@@ -34,6 +34,7 @@
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 
+require 'openssl'
 require 'sensu-plugin/check/cli'
 require 'socket'
 require 'timeout'
@@ -101,9 +102,22 @@ class CheckBanner < Sensu::Plugin::Check::CLI
          long: '--critmessage MESSAGE',
          description: 'Custom critical message to send'
 
+  option :ssl,
+         short: '-S',
+         long: '--ssl',
+         description: 'Enable SSL socket for secure connection'
+
   def acquire_banner(host)
     Timeout.timeout(config[:timeout]) do
       sock = TCPSocket.new(host, config[:port])
+
+      if config[:ssl]
+        ssl_context = OpenSSL::SSL::SSLContext.new
+        ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        sock = OpenSSL::SSL::SSLSocket.new(sock, ssl_context)
+        sock.connect
+      end
+
       if config[:write]
         sock.write config[:write]
         sock.write "\n" unless config[:exclude_newline]

--- a/bin/check-banner.rb
+++ b/bin/check-banner.rb
@@ -113,7 +113,6 @@ class CheckBanner < Sensu::Plugin::Check::CLI
 
       if config[:ssl]
         ssl_context = OpenSSL::SSL::SSLContext.new
-        ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
         sock = OpenSSL::SSL::SSLSocket.new(sock, ssl_context)
         sock.connect
       end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

This is useful when checking for banner and connection is secure (SSL/TLS).

A good example would be FTPS.

#### Known Compatibility Issues

Requires 'openssl'
