### PR TITLE
Fix undefined method deep_merge in check-multicast-groups.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Fixed
 - metrics-netstat-tcp.rb: Option to disable IPv6 check (#44 via @MattMencel)
+- check-multicast-groups.rb: Fix undefined method deep_merge for []:Array
 
 ### Changed
 - check-banner.rb: Option to enable SSL socket for secure connection

--- a/bin/check-multicast-groups.rb
+++ b/bin/check-multicast-groups.rb
@@ -51,7 +51,7 @@ class CheckMulticastGroups < Sensu::Plugin::Check::CLI
   def run
     targets = settings['check-multicast-groups'] ||= []
     extras = load_config(config[:config])['check-multicast-groups'] || []
-    targets.deep_merge(extras)
+    targets = targets.concat(extras).uniq
 
     critical 'No target muticast groups are specified.' if targets.empty?
 

--- a/bin/check-multicast-groups.rb
+++ b/bin/check-multicast-groups.rb
@@ -64,7 +64,7 @@ class CheckMulticastGroups < Sensu::Plugin::Check::CLI
     expected = Set.new(targets)
 
     diff = expected.difference(actual)
-    if diff.size > 0 # rubocop:disable Style/ZeroLengthPredicate
+    unless diff.empty?
       diff_output = diff.map { |iface, addr| "#{iface}\t#{addr}" }.join("\n")
       critical "#{diff.size} missing multicast group(s):\n#{diff_output}"
     end

--- a/bin/check-multicast-groups.rb
+++ b/bin/check-multicast-groups.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 #
-#   check-multicasr-groups
+#   check-multicast-groups
 #
 # DESCRIPTION:
 #   This plugin checks if specific multicast groups are configured


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No, it fixes a new issue.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

`sensu-plugin` has stopped monkey patching `Array` with `deep_merge`. This causes `check-multicast-groups` to fail:

```
% /opt/sensu/embedded/bin/ruby ./bin/check-multicast-groups.rb -c network.json
CheckMulticastGroups CRITICAL: Failed to check multicast groups: undefined method `deep_merge' for []:Array
```

This PR is a fix for this with minor corrections.

#### Known Compatablity Issues

I'm not aware of any compatibility issues. I believe the new code is also compatible with older `sensu-plugin`.