### PR TITLE
Added interval option to metrics-netif.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
 - Added check-ports-bind.rb
+- Added interval option to metrics-netif.rb
 
 ### Fixed
 - metrics-netstat-tcp.rb: Option to disable IPv6 check (#44 via @MattMencel)

--- a/bin/metrics-netif.rb
+++ b/bin/metrics-netif.rb
@@ -37,8 +37,13 @@ class NetIFMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--scheme SCHEME',
          default: Socket.gethostname.to_s
 
+  option :interval,
+         description: 'Interval to collect metrics over',
+         long: '--interval INTERVAL',
+         default: 1
+
   def run
-    `sar -n DEV 1 1 | grep Average | grep -v IFACE`.each_line do |line|
+    `sar -n DEV #{config[:interval]} 1 | grep Average | grep -v IFACE`.each_line do |line|
       stats = line.split(/\s+/)
       unless stats.empty?
         stats.shift


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

#### Purpose

Add the option to collect interface metrics over a longer period of time for a better average, Useful for those of us using a TSDB (i.e. Graphite) with precision set to minutely -- Collecting over 30 seconds would give a better general average than a 1 second collection.

#### Known Compatablity Issues

None - Default value matches that of existing check

