### PR TITLE
Stop using settings['check-multicast-groups']

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Changes
+- check-multicast-groups.rb: Stop loading system wide settings from `settings['check-multicast-groups']` and use only the config specified as `-c` (#57 via @maoe)
+
 ## [1.2.0] - 2017-06-07
 ### Added
 - Added check-ports-bind.rb (@hanynowsky)

--- a/bin/check-multicast-groups.rb
+++ b/bin/check-multicast-groups.rb
@@ -49,10 +49,7 @@ class CheckMulticastGroups < Sensu::Plugin::Check::CLI
          description: 'Path to a config file'
 
   def run
-    targets = settings['check-multicast-groups'] ||= []
-    extras = load_config(config[:config])['check-multicast-groups'] || []
-    targets = targets.concat(extras).uniq
-
+    targets = load_config(config[:config])['check-multicast-groups'] || []
     critical 'No target muticast groups are specified.' if targets.empty?
 
     iface_pat = /[a-zA-Z0-9\.]+/


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] ~~Update README with any necessary configuration snippets~~

- [x] ~~Binstubs are created if needed~~

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [x] ~~Tests~~

- [x] ~~Add the plugin to the README~~

- [x] ~~Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)~~

#### Purpose

Loading targets from `settings['check-multicast-groups']` can be inconvenient if the user want to put multiple configs in the sensu config path as it merges all the available targets. This patch stops the plugin from loading `settings['check-multicast-groups']` and have it use only the specified config.

#### Known Compatablity Issues

This is technically a breaking change but I expected the impact to be negligible because it makes no sense to run multiple checks that have the same targets in the system settings. So I think all the users must not be using the system settings.