### PR TITLE
Add whois-parser to check-whois-domain-expiration.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Fixed
 - misc changelog na PR template fixes (@majormoses)
+- check-whois-domain-expiration.rb: "Check failed to run: invalid date" caused by a change to the whois gem which removed the parser from the main repository (issue #59) (@akatch)
 
 ## [2.0.0] 2017-06-07
 ### Breaking Changes

--- a/bin/check-whois-domain-expiration-multi.rb
+++ b/bin/check-whois-domain-expiration-multi.rb
@@ -29,6 +29,7 @@
 
 require 'sensu-plugin/check/cli'
 require 'whois'
+require 'whois-parser'
 
 #
 # Check Whois domain expiration
@@ -86,7 +87,7 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
       whois = Whois::Client.new(timeout: config[:timeout])
       begin
         tries ||= 0
-        whois_result = whois.lookup(domain)
+        whois_result = whois.lookup(domain).parser
       rescue Timeout::Error, Errno::ECONNRESET, Whois::ConnectionError
         tries += 1
         tries < max_retries ? retry : next

--- a/bin/check-whois-domain-expiration.rb
+++ b/bin/check-whois-domain-expiration.rb
@@ -27,6 +27,7 @@
 
 require 'sensu-plugin/check/cli'
 require 'whois'
+require 'whois-parser'
 
 #
 # Check Whois domain expiration
@@ -74,7 +75,7 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
   def initialize
     super()
     whois = Whois.whois(config[:domain])
-    @expires_on = DateTime.parse(whois.expires_on.to_s)
+    @expires_on = DateTime.parse(whois.parser.expires_on.to_s)
     @num_days = (@expires_on - DateTime.now).to_i
   end
 

--- a/sensu-plugins-network-checks.gemspec
+++ b/sensu-plugins-network-checks.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sensu-plugin',  '~> 1.2'
   s.add_runtime_dependency 'net-ping',      '1.7.8'
   s.add_runtime_dependency 'whois',         '3.6.3'
+  s.add_runtime_dependency 'whois-ruby',    '~> 4.0'
   s.add_runtime_dependency 'activesupport', '~> 4.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'

--- a/sensu-plugins-network-checks.gemspec
+++ b/sensu-plugins-network-checks.gemspec
@@ -33,8 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'dnsbl-client',  '1.0.2'
   s.add_runtime_dependency 'sensu-plugin',  '~> 1.2'
   s.add_runtime_dependency 'net-ping',      '1.7.8'
-  s.add_runtime_dependency 'whois',         '3.6.3'
-  s.add_runtime_dependency 'whois-ruby',    '~> 4.0'
+  s.add_runtime_dependency 'whois-ruby',    '>= 4.0'
   s.add_runtime_dependency 'activesupport', '~> 4.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'

--- a/sensu-plugins-network-checks.gemspec
+++ b/sensu-plugins-network-checks.gemspec
@@ -33,7 +33,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'dnsbl-client',  '1.0.2'
   s.add_runtime_dependency 'sensu-plugin',  '~> 1.2'
   s.add_runtime_dependency 'net-ping',      '1.7.8'
-  s.add_runtime_dependency 'whois-ruby',    '>= 4.0'
+  s.add_runtime_dependency 'whois',         '>= 4.0'
+  s.add_runtime_dependency 'whois-parser',  '1.0.0'
   s.add_runtime_dependency 'activesupport', '~> 4.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
## Pull Request Checklist

This pull request is in response to #59 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
To add the new whois-parser gem for use with the whois domain expiration checks.

#### Known Compatibility Issues
N/A