### PR TITLE
Fix check-whois-domain-expiration-multi.rb to report a critical error on a domain that it gets back an empty expires_on.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Fixed
+- check-whois-domain-expiration-multi.rb: report a `critical` error on a domain that it gets back an empty expires_on. (@edgan)
 
 ## [2.1.0] - 2017-11-03
 ### Added

--- a/bin/check-whois-domain-expiration-multi.rb
+++ b/bin/check-whois-domain-expiration-multi.rb
@@ -93,7 +93,9 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
         tries < max_retries ? retry : next
       end
 
-      unless whois_result.expires_on.nil?
+      if whois_result.expires_on.nil?
+        results['critical'][domain] = domain_result
+      else
         domain_result = (DateTime.parse(whois_result.expires_on.to_s) - DateTime.now).to_i
         if domain_result <= critical_days
           results['critical'][domain] = domain_result
@@ -102,8 +104,6 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
         else
           results['ok'] = domain_result
         end
-      else
-        results['critical'][domain] = domain_result
       end
     end
     results

--- a/bin/check-whois-domain-expiration-multi.rb
+++ b/bin/check-whois-domain-expiration-multi.rb
@@ -102,6 +102,8 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
         else
           results['ok'] = domain_result
         end
+      else
+        results['critical'][domain] = domain_result
       end
     end
     results


### PR DESCRIPTION
#### General

The code before didn't throw an error for empty expires_on. This would mean if the whois-parser gem is failing to return a result you could have a false negative. The solution is to throw an error and force a fix to get a proper answer.

I was having this issue with the TLDs .co and .us. I separately made pull requests to fix them with whois-parser.