### PR TITLE
Address bug in check-whois-domain-expiration-multi.rb causing it to crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Fixed
+- check-whois-domain-expiration-multi.rb: fixed an issue causing the script to crash by accessing a variable before assignment and should return the raw `whois` result so it can be used to troubleshoot issue with infrastructure or monitoring script (@majormoses)
+
 ## [2.1.1] - 2018-01-06
 ### Fixed
 - check-whois-domain-expiration-multi.rb: report a `critical` error on a domain that it gets back an empty expires_on. (@edgan)

--- a/bin/check-whois-domain-expiration-multi.rb
+++ b/bin/check-whois-domain-expiration-multi.rb
@@ -94,7 +94,7 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
       end
 
       if whois_result.expires_on.nil?
-        results['critical'][domain] = domain_result
+        results['critical'][domain] = whois_result
       else
         domain_result = (DateTime.parse(whois_result.expires_on.to_s) - DateTime.now).to_i
         if domain_result <= critical_days


### PR DESCRIPTION
fix issue with accessing a variable that can't exist yet, return the raw results.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

fixes #67 

caused by #65 

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Fix an issue where `expires_on` is nil and breaks rather than returning the proper critical result.

#### Known Compatibility Issues
None