### PR TITLE
Update whois-parser gem to 1.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- update whois-parser gem dependency to version 1.0.1 (@amdprophet)
 
 ## [2.3.0] - 2018-02-09
 ### Changed

--- a/sensu-plugins-network-checks.gemspec
+++ b/sensu-plugins-network-checks.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sensu-plugin',  '~> 1.2'
   s.add_runtime_dependency 'net-ping',      '1.7.8'
   s.add_runtime_dependency 'whois',         '>= 4.0'
-  s.add_runtime_dependency 'whois-parser',  '1.0.0'
+  s.add_runtime_dependency 'whois-parser',  '~> 1.0.0'
   s.add_runtime_dependency 'activesupport', '~> 4.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
## Pull Request Checklist

Fixes #73.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Fixes #73 by bumping the `whois-parser` gem to version 1.0.1 (https://github.com/weppos/whois-parser/blob/master/CHANGELOG.md).

#### Known Compatibility Issues

N/A