### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,23 @@ Style/Next:
 
 Style/MultilineTernaryOperator:
   Enabled: false
+
+# safe navigation was introduced in ruby 2.3
+Style/SafeNavigation:
+  Enabled: false
+
+# match?() was added in ruby 2.4
+Performance/RegexpMatch:
+  Enabled: false
+
+
+# TODO: figure out which to use `Date` or `Time`
+Style/DateTime:
+  Enabled: false
+
+
+# testing can be slow
+Metrics/BlockLength:
+  Enabled: true
+  Exclude:
+    - 'test/**/*.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This CHANGELOG follows the format listed  [here](https://github.com/sensu-plugin
 
 ## [Unreleased]
 
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Breaking Changes
+- removed ruby `< 2.1` support (@majormoses)
+
+### Changed
+- appeased the cops and updated cop config (@majormoses)
+
 ## [2.3.1] - 2018-02-28
 ### Changed
 - update whois-parser gem dependency to version 1.0.1 (@amdprophet)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-network-checks.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'github/markup'
 require 'redcarpet'
@@ -7,12 +9,12 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 desc 'Don\'t run Rubocop for unsupported versions'
-args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+args = %i[spec make_bin_executable yard rubocop check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new

--- a/bin/check-banner.rb
+++ b/bin/check-banner.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
-#  encoding: UTF-8
 #   check-banner
 #
 # DESCRIPTION:

--- a/bin/check-jsonwhois-domain-expiration.rb
+++ b/bin/check-jsonwhois-domain-expiration.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+# frozen_string_literal: false
+
 #
 #   check-jsonwhois-domain-expiration
 #
@@ -72,7 +73,7 @@ class JSONWhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
          short: '-r LEVEL',
          long: '--report-errors LEVEL',
          proc: proc(&:to_sym),
-         in: %i(unknown warning critical),
+         in: %i[unknown warning critical],
          default: :unknown,
          description: 'Level for reporting connection or parsing errors'
 
@@ -110,7 +111,7 @@ class JSONWhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
         else
           results[:ok][domain] = domain_result
         end
-      rescue
+      rescue StandardError
         results[:unknown][domain] = 'Connection or parsing error' unless config[:'ignore-errors']
       end
     end

--- a/bin/check-mtu.rb
+++ b/bin/check-mtu.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-mtu.rb
 #

--- a/bin/check-multicast-groups.rb
+++ b/bin/check-multicast-groups.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 #   check-multicast-groups
 #
@@ -66,7 +68,7 @@ class CheckMulticastGroups < Sensu::Plugin::Check::CLI
       critical "#{diff.size} missing multicast group(s):\n#{diff_output}"
     end
     ok
-  rescue => ex
+  rescue StandardError => ex
     critical "Failed to check multicast groups: #{ex}"
   end
 end

--- a/bin/check-netfilter-conntrack.rb
+++ b/bin/check-netfilter-conntrack.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-bin_dir = File.expand_path(File.dirname(__FILE__))
+bin_dir = File.expand_path(__dir__)
 shell_script_path = File.join(bin_dir, File.basename($PROGRAM_NAME, '.rb') + '.sh')
 
 exec shell_script_path, *ARGV

--- a/bin/check-netstat-tcp.rb
+++ b/bin/check-netstat-tcp.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-netstat-tcp
 #
@@ -102,7 +104,7 @@ class CheckNetstatTCP < Sensu::Plugin::Check::CLI
   end
 
   def run
-    state_counts = netstat(%w(tcp tcp6))
+    state_counts = netstat(%w[tcp tcp6])
     is_critical = false
     is_warning = false
     message = ''

--- a/bin/check-ping.rb
+++ b/bin/check-ping.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #  check-ping
 #
@@ -83,7 +85,7 @@ class CheckPING < Sensu::Plugin::Check::CLI
     pt = Net::Ping::External.new(config[:host], nil, config[:timeout])
 
     config[:count].times do |i|
-      sleep(config[:interval]) unless i == 0
+      sleep(config[:interval]) unless i.zero?
       result[i] = config[:ipv6] ? pt.ping6 : pt.ping
     end
 

--- a/bin/check-ports-bind.rb
+++ b/bin/check-ports-bind.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
-#  encoding: UTF-8
 #   check-ports-bind
 #
 # DESCRIPTION:

--- a/bin/check-ports-nmap.rb
+++ b/bin/check-ports-nmap.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-ports-nmap
 #

--- a/bin/check-ports.rb
+++ b/bin/check-ports.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
-#  encoding: UTF-8
 #   check-ports
 #
 # DESCRIPTION:

--- a/bin/check-rbl.rb
+++ b/bin/check-rbl.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-rbl
 #
@@ -89,7 +91,7 @@ class RblCheck < Sensu::Plugin::Check::CLI
 
     # YELLOW
     unless msg_string.empty? # rubocop:disable UnlessElse
-      if criticality > 0
+      if criticality.positive?
         critical "#{ip_add} Blacklisted in#{msg_string}"
       else
         warning "#{ip_add} Blacklisted in#{msg_string}"

--- a/bin/check-socat.rb
+++ b/bin/check-socat.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: false
+
 #
 #   check-socat
 #

--- a/bin/check-whois-domain-expiration-multi.rb
+++ b/bin/check-whois-domain-expiration-multi.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+# frozen_string_literal: false
+
 #
 #   check-whois-domain-expiration-multi
 #
@@ -66,7 +67,7 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
          short: '-r LEVEL',
          long: '--report-errors LEVEL',
          proc: proc(&:to_sym),
-         in: %i(unknown warning critical),
+         in: %i[unknown warning critical],
          default: :unknown,
          description: 'Level for reporting connection or parsing errors'
 
@@ -126,7 +127,7 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
         else
           results[:ok][domain] = domain_result
         end
-      rescue
+      rescue StandardError
         results[:unknown][domain] = 'Parsing error' unless config[:'ignore-errors']
       end
     end

--- a/bin/check-whois-domain-expiration.rb
+++ b/bin/check-whois-domain-expiration.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+# frozen_string_literal: false
+
 #
 #   check-whois-domain-expiration
 #
@@ -63,6 +64,7 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
   def run
     whois = Whois.whois(config[:domain])
 
+    # TODO: figure out which to use `Date` or `Time`
     expires_on = DateTime.parse(whois.parser.expires_on.to_s)
     num_days = (expires_on - DateTime.now).to_i
 
@@ -75,7 +77,7 @@ class WhoisDomainExpirationCheck < Sensu::Plugin::Check::CLI
     else
       ok
     end
-  rescue
+  rescue StandardError
     unknown "#{config[:domain]} can't be checked"
   end
 end

--- a/bin/metrics-interface.rb
+++ b/bin/metrics-interface.rb
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
+# frozen_string_literal: true
+
 #
 #   interface-metrics
 #
@@ -52,7 +53,7 @@ class InterfaceGraphite < Sensu::Plugin::Metric::CLI::Graphite
   def run
     # Metrics borrowed from hoardd: https://github.com/coredump/hoardd
 
-    metrics = %w(rxBytes
+    metrics = %w[rxBytes
                  rxPackets
                  rxErrors
                  rxDrops
@@ -67,7 +68,7 @@ class InterfaceGraphite < Sensu::Plugin::Metric::CLI::Graphite
                  txFifo
                  txColls
                  txCarrier
-                 txCompressed)
+                 txCompressed]
 
     File.open('/proc/net/dev', 'r').each_line do |line|
       interface, stats_string = line.scan(/^\s*([^:]+):\s*(.*)$/).first

--- a/bin/metrics-net.rb
+++ b/bin/metrics-net.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   metrics-net
 #
@@ -91,7 +93,7 @@ class LinuxPacketMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
       begin
         if_speed = File.open(iface_path + '/speed').read.strip
-      rescue
+      rescue StandardError
         if_speed = 0
       end
 

--- a/bin/metrics-netif.rb
+++ b/bin/metrics-netif.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   netif-metrics
 #

--- a/bin/metrics-netstat-tcp.rb
+++ b/bin/metrics-netstat-tcp.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   metrics-netstat-tcp
 #

--- a/bin/metrics-ping.rb
+++ b/bin/metrics-ping.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # metrics-ping
 #
@@ -69,8 +71,8 @@ class PingMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--timeout TIMEOUT',
          default: 5
 
-  OVERVIEW_METRICS = [:packets_transmitted, :packets_received, :packet_loss, :time].freeze
-  STATISTIC_METRICS = [:min, :avg, :max, :mdev].freeze
+  OVERVIEW_METRICS = %i[packets_transmitted packets_received packet_loss time].freeze
+  STATISTIC_METRICS = %i[min avg max mdev].freeze
   FLOAT = '(\d+\.\d+)'.freeze
 
   def overview

--- a/bin/metrics-sockstat.rb
+++ b/bin/metrics-sockstat.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # metrics-sockstat
 #
@@ -54,7 +56,7 @@ class MetricsSockstat < Sensu::Plugin::Metric::CLI::Graphite
 
   def read_sockstat
     return IO.read('/proc/net/sockstat')
-  rescue => e
+  rescue StandardError => e
     unknown "Failed to read /proc/net/sockstat: #{e}"
   end
 

--- a/lib/sensu-plugins-network-checks.rb
+++ b/lib/sensu-plugins-network-checks.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'sensu-plugins-network-checks/version'

--- a/lib/sensu-plugins-network-checks/version.rb
+++ b/lib/sensu-plugins-network-checks/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SensuPluginsNetworkChecks
   module Version
     MAJOR = 2

--- a/sensu-plugins-network-checks.gemspec
+++ b/sensu-plugins-network-checks.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -5,7 +7,7 @@ require 'date'
 
 require_relative 'lib/sensu-plugins-network-checks'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
   s.date                   = Date.today.to_s
   s.description            = 'This plugin provides native network instrumentation
@@ -13,7 +15,7 @@ Gem::Specification.new do |s|
                               hardware, TCP response, RBLs, whois, port status, and more'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-network-checks'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -25,17 +27,18 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
   s.summary                = 'Sensu plugins for checking network hardware, connections, and data'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsNetworkChecks::Version::VER_STRING
 
-  s.add_runtime_dependency 'dnsbl-client',  '1.0.2'
   s.add_runtime_dependency 'sensu-plugin',  '~> 1.2'
+
+  s.add_runtime_dependency 'activesupport', '~> 4.2'
+  s.add_runtime_dependency 'dnsbl-client',  '1.0.2'
   s.add_runtime_dependency 'net-ping',      '1.7.8'
   s.add_runtime_dependency 'whois',         '>= 4.0'
   s.add_runtime_dependency 'whois-parser',  '~> 1.0.0'
-  s.add_runtime_dependency 'activesupport', '~> 4.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
@@ -45,6 +48,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc',                      '~> 4.2.1'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/test/check-mtu_spec.rb
+++ b/test/check-mtu_spec.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-mtu_spec
 #

--- a/test/check-ports_spec.rb
+++ b/test/check-ports_spec.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-ports_spec
 #

--- a/test/metrics-sockstat_spec.rb
+++ b/test/metrics-sockstat_spec.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # metrics-sockstat_spec
 #

--- a/test/plugin_stub.rb
+++ b/test/plugin_stub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |c|
   # XXX: Sensu plugins run in the context of an at_exit handler. This prevents
   # XXX: code-under-test from being run at the end of the rspec suite.

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start


### PR DESCRIPTION
Breaking Changes:
- removed `< 2.1` ruby support

Misc:
- appeased the cops

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Address CVE, see parent issue for details
#### Known Compatibility Issues
removed ruby `< 2.1 support`