### PR TITLE
Feature/only up ifs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed  [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+## [3.1.3] - 2018-08-02
+### Added
+ - metrics-net.rb: allow including only interfaces whos status is `up` (@johannagnarsson)
 
 ## [3.1.2] - 2018-06-10
 ### Fixed

--- a/bin/metrics-net.rb
+++ b/bin/metrics-net.rb
@@ -73,6 +73,11 @@ class LinuxPacketMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--include-device',
          proc: proc { |a| a.split(',') }
 
+  option :only_up,
+         description: 'Include only devices whose interface status is up',
+         short: '-u',
+         long: '--only-up'
+
   def run
     timestamp = Time.now.to_i
 
@@ -83,6 +88,7 @@ class LinuxPacketMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
       next if config[:ignore_device] && config[:ignore_device].find { |x| iface.match(x) }
       next if config[:include_device] && !config[:include_device].find { |x| iface.match(x) }
+      next if config[:only_up] && File.open(iface_path + '/operstate').read.strip != 'up'
 
       tx_pkts = File.open(iface_path + '/statistics/tx_packets').read.strip
       rx_pkts = File.open(iface_path + '/statistics/rx_packets').read.strip

--- a/lib/sensu-plugins-network-checks/version.rb
+++ b/lib/sensu-plugins-network-checks/version.rb
@@ -4,7 +4,7 @@ module SensuPluginsNetworkChecks
   module Version
     MAJOR = 3
     MINOR = 1
-    PATCH = 2
+    PATCH = 3
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** 
Indirectly, but this would help with this issue, Interface would be omitted from output:

https://github.com/sensu-plugins/sensu-plugins-network-checks/issues/40

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
To allow the metrics-net script to only display output from network interfaces that are in the 'up' state. Interfaces in any other state will be omitted. 

Many of our hosts have dual nics and/or virtual bridge interfaces that will never be in an 'up' state and all of their metrics will be 0. This patch allows simply excluding them from being sent to metric collections.

#### Known Compatibility Issues
None. 