### PR TITLE
Fix installation by pinning whois gem v4

### DIFF
--- a/sensu-plugins-network-checks.gemspec
+++ b/sensu-plugins-network-checks.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency 'activesupport', '~> 4.2'
   s.add_runtime_dependency 'dnsbl-client',  '1.0.4'
   s.add_runtime_dependency 'net-ping',      '2.0.6'
-  s.add_runtime_dependency 'whois',         '>= 4.0'
+  s.add_runtime_dependency 'whois',         '~> 4.0'
   s.add_runtime_dependency 'whois-parser',  '~> 1.2'
 
   s.add_development_dependency 'bundler',                   '~> 2.1'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

The recent update of the whois gem to version 6.0.0 has raised the minimum required Ruby version to 3.0. 
https://rubygems.org/gems/whois/versions/6.0.0

This change has caused the `sensu-install -p sensu-plugins-network-checks` command to fail with the following error:

```
sensu-install -p sensu-plugins-network-checks
[SENSU-INSTALL] installing Sensu plugins ...
[SENSU-INSTALL] determining if Sensu gem 'sensu-plugins-network-checks' is already installed ...
false
[SENSU-INSTALL] Sensu plugin gems to be installed: ["sensu-plugins-network-checks"]
[SENSU-INSTALL] installing Sensu gem 'sensu-plugins-network-checks'
ERROR:  Error installing sensu-plugins-network-checks:
        whois requires Ruby version >= 3.0.
```

To address this issue, I have pinned the whois gem to the last compatible major version 4.

#### Known Compatibility Issues
